### PR TITLE
Update filters upon selecting a preset image

### DIFF
--- a/src/filters/components/gallery/gallery.ts
+++ b/src/filters/components/gallery/gallery.ts
@@ -15,7 +15,7 @@ import './gallery.scss';
         <ul class="gallery-items" *ngIf="gallery.length">
           <li class="gallery-item" *ngFor="let record of gallery; let idx = index;">
             <div class="thumb" 
-              [ngClass]="{'selected': idx === selected }" 
+              [ngClass]="{'selected': idx === selected && !customFilters }" 
               (click)="select(record.figureStyle, record.overlayStyle, idx, record.key)">
               <figure class="thumb__figure" [ngStyle]="record.figureStyle">
                 <div [ngStyle]="record.overlayStyle"></div>
@@ -33,6 +33,7 @@ import './gallery.scss';
 export class GalleryComponent implements OnChanges {
   @Input() image: string;
   @Input() active: boolean = true;
+  @Input() customFilters: boolean;
   @Output() onSelect: EventEmitter<any> = new EventEmitter<any>(false);
 
   gallery: GalleryModel[] = [];
@@ -57,7 +58,7 @@ export class GalleryComponent implements OnChanges {
   }
 
   select(figure: FilterStyle, overlay: OverlayStyle, id: number, key: string): void {
-    if (this.selected !== id) {
+    if (this.selected !== id || this.customFilters) {
       this.selected = id;
       const figureStyle = fromJS(figure);
       const overlayStyle = fromJS(overlay);

--- a/src/filters/components/gallery/gallery.ts
+++ b/src/filters/components/gallery/gallery.ts
@@ -16,7 +16,7 @@ import './gallery.scss';
           <li class="gallery-item" *ngFor="let record of gallery; let idx = index;">
             <div class="thumb" 
               [ngClass]="{'selected': idx === selected }" 
-              (click)="select(record.figureStyle, record.overlayStyle, idx)">
+              (click)="select(record.figureStyle, record.overlayStyle, idx, record.key)">
               <figure class="thumb__figure" [ngStyle]="record.figureStyle">
                 <div [ngStyle]="record.overlayStyle"></div>
                 <img class="thumb__img" [src]="record.image" >
@@ -56,12 +56,12 @@ export class GalleryComponent implements OnChanges {
     }
   }
 
-  select(figure: FilterStyle, overlay: OverlayStyle, id: number): void {
+  select(figure: FilterStyle, overlay: OverlayStyle, id: number, key: string): void {
     if (this.selected !== id) {
       this.selected = id;
       const figureStyle = fromJS(figure);
       const overlayStyle = fromJS(overlay);
-      this.onSelect.emit({ figureStyle, overlayStyle });
+      this.onSelect.emit({ figureStyle, overlayStyle, key });
     }
   }
 
@@ -71,6 +71,7 @@ export class GalleryComponent implements OnChanges {
       const name = key.replace(/^./, key[0].toUpperCase());
       const object = presets[key];
       data.push({
+        key: key,
         labelName: name,
         image: src,
         figureStyle: this.getGalleryFigureStyle(object.filter),

--- a/src/filters/components/slider/md-slider.ts
+++ b/src/filters/components/slider/md-slider.ts
@@ -50,7 +50,7 @@ export const MD_SLIDER_VALUE_ACCESSOR: any = {
   template:`
   <div class="md-slider-wrapper">
     <div class="md-slider-container"
-       [class.md-slider-sliding]="isSliding"
+       [class.md-slider-sliding]="isSliding && isActive"
        [class.md-slider-active]="isActive"
        [class.md-slider-thumb-label-showing]="thumbLabel">
       <div class="md-slider-track-container">

--- a/src/filters/interfaces.ts
+++ b/src/filters/interfaces.ts
@@ -19,6 +19,7 @@ export interface OverlayStyle {
 }
 
 export interface GalleryModel {
+  key: string;
   figureStyle: FilterStyle;
   overlayStyle: OverlayStyle;
   image: string;

--- a/src/filters/pages/filters-landing-page.ts
+++ b/src/filters/pages/filters-landing-page.ts
@@ -158,7 +158,7 @@ import './filters-landing-page.scss';
             [value]="filters.blur$ | async"
             (valueChange)="change($event)">          
           </md-slider>
-          
+
           <div>
             <section>
               <p class="header overlay">Overlay:</p>           
@@ -210,11 +210,12 @@ export class FiltersLandingPageComponent {
     this.filters.loadAllImages();
   }
 
-  select({ figureStyle, overlayStyle }: { figureStyle: any, overlayStyle: any }): void {
+  select({ figureStyle, overlayStyle, key }: { figureStyle: any, overlayStyle: any, key: string }): void {
     this.filters.change({
       value: {
         figureStyle: figureStyle,
-        overlayStyle: overlayStyle
+        overlayStyle: overlayStyle,
+        key: key
       },
       type: FiltersService.PRESET
     });

--- a/src/filters/pages/filters-landing-page.ts
+++ b/src/filters/pages/filters-landing-page.ts
@@ -19,6 +19,7 @@ import './filters-landing-page.scss';
       <gallery 
        [image]="filters.selectedImage$ | async"
        [active]="!isActive"
+       [customFilters]="customFilters"
        (onSelect)="select($event)">      
       </gallery>
          
@@ -202,6 +203,7 @@ import './filters-landing-page.scss';
 export class FiltersLandingPageComponent {
   options: Object[] = overlayOptions || [];
   isActive: boolean;
+  customFilters: boolean = true;
 
   constructor(
     public filters: FiltersService,
@@ -211,6 +213,7 @@ export class FiltersLandingPageComponent {
   }
 
   select({ figureStyle, overlayStyle, key }: { figureStyle: any, overlayStyle: any, key: string }): void {
+    this.customFilters = false;
     this.filters.change({
       value: {
         figureStyle: figureStyle,
@@ -222,6 +225,7 @@ export class FiltersLandingPageComponent {
   }
 
   change({ value, type }: { value: number, type: string }): void {
+    this.customFilters = true;
     this.filters.change({ value, type });
   }
 

--- a/src/filters/reducers/filters-reducer.ts
+++ b/src/filters/reducers/filters-reducer.ts
@@ -1,7 +1,8 @@
 import { Action } from '@ngrx/store';
 import { Map, List } from 'immutable';
 import { FiltersActions } from '../services/filters-actions';
-import { FilterStyle, OverlayStyle } from 'src/filters';
+import { FilterStyle, OverlayStyle, presets } from 'src/filters';
+
 
 export type FiltersState = Map<string, any>;
 const defaultImage: string = 'https://source.unsplash.com/W_9mOGUwR08/800x600';
@@ -71,8 +72,20 @@ export function filtersReducer(state: FiltersState = initialState, { type, paylo
 
     case FiltersActions.CHANGE_PRESET:
       return state.withMutations(filtersState => {
-        const { figureStyle, overlayStyle } = payload;
+        const { figureStyle, overlayStyle, key } = payload;
+        const preset = presets[key];
+        const { filter, overlay } = preset;
         filtersState
+          .merge({ 'contrast'   : filter.get('contrast')    || 100    })
+          .merge({ 'brightness' : filter.get('brightness')  || 100    })
+          .merge({ 'saturate'   : filter.get('saturate')    || 100    })
+          .merge({ 'sepia'      : filter.get('saturate')    || 0      })
+          .merge({ 'grayScale'  : filter.get('grayscale')   || 0      })
+          .merge({ 'invert'     : filter.get('invert')      || 0      })
+          .merge({ 'hueRotate'  : filter.get('hueRotate')   || 0      })
+          .merge({ 'blur'       : filter.get('blur')        || 0      })
+          .merge({ 'blend'      : filter.get('blend')       || 'none' })
+          .merge({ 'opacity'    : filter.get('opacity')     || 50     })
           .set('styles', figureStyle)
           .set('overlay', overlayStyle);
       });

--- a/src/filters/services/filters-actions.spec.ts
+++ b/src/filters/services/filters-actions.spec.ts
@@ -127,7 +127,7 @@ describe('filters', () => {
 
     describe('changePreset()', () => {
       it('should create an action', () => {
-        const value = { figureStyle: {}, overlayStyle: {} };
+        const value = { figureStyle: {}, overlayStyle: {}, key: '' };
         const action = actions.changePreset(value);
 
         expect(action).toEqual({

--- a/src/filters/services/filters-actions.ts
+++ b/src/filters/services/filters-actions.ts
@@ -110,12 +110,13 @@ export class FiltersActions {
     };
   }
 
-  changePreset({ figureStyle, overlayStyle }: { figureStyle: any, overlayStyle: any }): Action {
+  changePreset({ figureStyle, overlayStyle, key }: { figureStyle: any, overlayStyle: any, key: string }): Action {
     return {
       type: FiltersActions.CHANGE_PRESET,
       payload: {
         figureStyle,
-        overlayStyle
+        overlayStyle,
+        key
       }
     };
   }

--- a/src/filters/services/filters-service.ts
+++ b/src/filters/services/filters-service.ts
@@ -172,7 +172,7 @@ export class FiltersService {
     );
   }
 
-  changePreset(value: { figureStyle: any, overlayStyle: any }): void {
+  changePreset(value: { figureStyle: any, overlayStyle: any, key: string }): void {
     this.store$.dispatch(
       this.actions.changePreset(value)
     );


### PR DESCRIPTION
Hi Jay, this should solve #2
I did a couple of side changes in order to:
1. Deselect a gallery preset after the filters are changed since that preset is no longer corresponding to the filters panel configuration
2. Make the sliders move smoothly by removing the `md-slider-sliding` when `isActive` is falsy

Let me know how does it look, thanks.