### PR TITLE
feat: implemented Swiper.js on gallery cmp

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "express": "^4.14.0",
     "helmet": "^3.4.1",
     "serve-favicon": "^2.3.0",
+    "swiper": "^3.4.2",
     "winston": "^2.2.0"
   },
   "devDependencies": {
@@ -55,6 +56,7 @@
     "@types/jquery": "^2.0.34",
     "@types/node": "~7.0.5",
     "@types/slick-carousel": "^1.6.31",
+    "@types/swiper": "^3.4.0",
     "autoprefixer": "^6.5.1",
     "compression-webpack-plugin": "^0.3.2",
     "copy-webpack-plugin": "^4.0.0",

--- a/src/filters/components/gallery-v2/gallery.scss
+++ b/src/filters/components/gallery-v2/gallery.scss
@@ -1,0 +1,68 @@
+@import '../../../shared/styles/utils';
+
+gallery {
+  background-color: c('base', 'tab-bg-color');
+
+  .swiper-container {
+    background-color: c('base', 'tab-bg-color');
+    width: 100%;
+    height: 100%;
+
+    .swiper-wrapper {
+      display: block;
+      white-space: nowrap;
+      margin: 15px 20px 20px 20px;
+
+      .swiper-slide {
+        width: 100px;
+        display: inline-block;
+        &:first-child {
+          margin-left: 0;
+        }
+
+        &:hover {
+          transform: scale(1.03, 1.03);
+        }
+      }
+    }
+
+    .thumb {
+      border: solid 1px c('base', 'border-color');
+      border-radius: 2px;
+      cursor: pointer;
+      overflow: hidden;
+      padding-bottom: 0;
+
+      &.selected {
+        border: 2px solid #15b0ed;
+      }
+
+      &.is-active {
+        border: solid 1px c('base', 'link-color');
+        .thumb__label { color: c('base', 'tab-label-color-active'); }
+      }
+
+      &__figure {
+        height: 75px;
+        position: relative;
+        width: 100px;
+      }
+
+      &__label {
+        color: c('base', 'slider-label-color');
+        font-size: 12px;
+        line-height: 2;
+        text-align: center;
+      }
+
+      &__img {
+        width: 100px;
+      }
+    }
+
+    .swiper-scrollbar-drag {
+      background: #11C966;
+    }
+  }
+
+}

--- a/src/filters/components/gallery-v2/gallery.ts
+++ b/src/filters/components/gallery-v2/gallery.ts
@@ -1,7 +1,10 @@
-import { Component, ViewEncapsulation, ChangeDetectionStrategy, Input, OnChanges, Output, EventEmitter } from '@angular/core';
+import { Component, ViewEncapsulation, ChangeDetectionStrategy, Input, OnChanges, AfterViewInit, Output, EventEmitter, ElementRef, ViewChild } from '@angular/core';
 import { FiltersState, GalleryModel, OverlayStyle, FilterStyle, presets } from 'src/filters';
 import { fromJS } from 'immutable';
+import * as Swiper from 'swiper';
+
 import './gallery.scss';
+import '../../../../node_modules/swiper/dist/css/swiper.css';
 
 @Component({
   selector: 'gallery',
@@ -9,52 +12,48 @@ import './gallery.scss';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template:`
   <section>
-    <div class="gallery gallery-scroll"
-      [ngClass]="{'is-active': active }">
-      <div class="gallery__scroll-cont dragscroll">
-        <ul class="gallery-items" *ngIf="gallery.length">
-          <li class="gallery-item" *ngFor="let record of gallery; let idx = index;">
-            <div class="thumb"
-              [ngClass]="{'selected': idx === selected && !customFilters }"
-              (click)="select(record.figureStyle, record.overlayStyle, idx, record.key)">
-              <figure class="thumb__figure" [ngStyle]="record.figureStyle">
-                <div [ngStyle]="record.overlayStyle"></div>
-                <img class="thumb__img" [src]="record.image" >
-              </figure>
-              <p class="thumb__label">{{ record.labelName }}</p>
-            </div>
-          </li>
-        </ul>
+    <div class="swiper-container" #swiper>
+      <div class="swiper-wrapper">
+        <div class="swiper-slide" *ngFor="let record of gallery; let idx = index;">
+          <div class="thumb"
+            [ngClass]="{'selected': idx === selected && !customFilters }"
+            (click)="select(record.figureStyle, record.overlayStyle, idx, record.key)">
+            <figure class="thumb__figure" [ngStyle]="record.figureStyle">
+              <div [ngStyle]="record.overlayStyle"></div>
+              <img class="thumb__img" [src]="record.image" >
+            </figure>
+            <p class="thumb__label">v2-{{ record.labelName }}</p>
+          </div>
+        </div>
       </div>
+      <div class="swiper-scrollbar" #scrollbar></div>
     </div>
   </section>
   `
 })
-export class GalleryComponent implements OnChanges {
+export class GalleryComponent implements OnChanges, AfterViewInit {
   @Input() image: string;
   @Input() active: boolean = true;
   @Input() customFilters: boolean;
   @Output() onSelect: EventEmitter<any> = new EventEmitter<any>(false);
 
+  @ViewChild('swiper') swiperGallery: ElementRef;
+  @ViewChild('scrollbar') scrollbar: ElementRef;
   gallery: GalleryModel[] = [];
-
   private selected: number;
-
-  settings: Object = {
-    dots: false,
-    infinite: false,
-    speed: 100,
-    slidesToShow: 6,
-    slidesToScroll: 4,
-    swipe: true,
-    swipeToSlide: true,
-    initialSlide: 0
-  };
 
   ngOnChanges(changes: any): void {
     if (changes.image) {
       this.gallery = this.getGalleryImages(changes.image.currentValue);
     }
+  }
+
+  ngAfterViewInit(): void {
+    var mySwiper = new Swiper (this.swiperGallery.nativeElement, {
+      spaceBetween: 10,
+      slidesPerView: 'auto',
+      scrollbar: this.scrollbar.nativeElement,
+    });
   }
 
   select(figure: FilterStyle, overlay: OverlayStyle, id: number, key: string): void {

--- a/src/filters/components/gallery-v2/index.ts
+++ b/src/filters/components/gallery-v2/index.ts
@@ -1,0 +1,1 @@
+export { GalleryComponent } from './gallery';

--- a/src/filters/index.ts
+++ b/src/filters/index.ts
@@ -16,7 +16,7 @@ import { FiltersEffects } from './services/filters-effects';
 import { PhotoComponent } from './components/photo';
 import { ImageLoaderComponent } from './components/image-loader';
 
-import { GalleryComponent } from './components/gallery';
+import { GalleryComponent } from './components/gallery-v2';
 import { SlickSliderComponent } from './components/slick-slider';
 
 import { MdSliderComponent } from './components/slider';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,6 +36,10 @@ const rules = {
     loader: 'raw-loader',
     exclude: path.resolve('src/index.html')
   },
+  css: {
+    test: /\.css$/,
+    use: [ 'style-loader', 'css-loader' ]
+  },
   scss: {
     test: /\.scss$/,
     loader: ExtractTextPlugin.extract('css-loader?-autoprefixer!postcss-loader!sass-loader')
@@ -64,6 +68,7 @@ config.resolve = {
 config.module = {
   rules: [
     rules.html,
+    rules.css,
     rules.scss,
     rules.typescript,
   ]
@@ -94,7 +99,13 @@ config.plugins = [
     /angular(\\|\/)core(\\|\/)(esm(\\|\/)src|src)(\\|\/)linker/,
     path.resolve('src')
   ),
-  new BundleAnalyzerPlugin(),
+  new BundleAnalyzerPlugin({
+    // this config can be removed when HMR will be supported
+    // https://github.com/th0r/webpack-bundle-analyzer/issues/37
+    analyzerMode: 'disabled',
+    generateStatsFile: true,
+    statsFilename: 'stats.json'
+  }),
 ];
 
 //=========================================================


### PR DESCRIPTION
Fix #5
Hi @JayKan please have a look at the current behavior and let me know if you like it.

A couple of side notes:
- `Webpack Bundle Analyzer` doesn't seem to work with HMR so I temporarely replaced that with a simple `.json` generated on the `/public` folder. Setting `{analyzerMode: 'static'}` works, but it opens a new page each time it live reloads.
- `npm run build` now fails because the original `gallery` cmp is still there. Everything should work once we remove it and rename `gallery-v2` to `gallery`

Looking forward to receiving your feedback. Thanks