### PR TITLE
fix: #10 gallery hide and thumb padding

### DIFF
--- a/src/filters/components/gallery/gallery.scss
+++ b/src/filters/components/gallery/gallery.scss
@@ -6,7 +6,12 @@ gallery {
   .swiper-container {
     background-color: c('base', 'tab-bg-color');
     width: 100%;
-    height: 100%;
+    height: 0;
+    transition: all .35s cubic-bezier(.42, 0, .42, .86) 0s;
+
+    &.is-active {
+      height: 148px;
+    }
 
     .swiper-wrapper {
       display: block;
@@ -16,6 +21,7 @@ gallery {
       .swiper-slide {
         width: 100px;
         display: inline-block;
+        margin-left: 15px;
         &:first-child {
           margin-left: 0;
         }

--- a/src/filters/components/gallery/gallery.ts
+++ b/src/filters/components/gallery/gallery.ts
@@ -11,7 +11,8 @@ import '../../../../node_modules/swiper/dist/css/swiper.css';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template:`
   <section>
-    <div class="swiper-container" #swiper>
+    <div class="swiper-container" #swiper
+      [ngClass]="{'is-active': active}">
       <div class="swiper-wrapper">
         <div class="swiper-slide" *ngFor="let record of gallery; let idx = index;">
           <div class="thumb"
@@ -49,7 +50,6 @@ export class GalleryComponent implements OnChanges, AfterViewInit {
 
   ngAfterViewInit(): void {
     const mySwiper = new Swiper(this.swiperGallery.nativeElement, {
-      spaceBetween: 15,
       slidesPerView: 'auto',
       scrollbar: this.scrollbar.nativeElement,
     });


### PR DESCRIPTION
Unfortunately it was not `Swiper`'s fault, rather mine that missed out a couple of css while refactoring.

I moved the preset images padding from the Swiper initialization to the css, otherwise we should reinitialize `Swiper` every time the image changed.