### PR TITLE
Fix electron reload

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "electron:dev": "npm run build:dev -- --env.electron",
     "electron:prod": "npm run build:electron && npm run electron:copy && cross-env NODE_ENV=production electron ./public",
     "electron:copy": "cp ./package.json ./public && cp ./src/electron/electron.js ./public",
-    "electron:package": "npm run build:electron && npm run electron:copy && electron-packager ./public --out=dist",
+    "electron:package": "npm run build:electron && npm run electron:copy && electron-packager ./public --out=dist --overwrite",
     "production": "npm run clean && npm run build && npm run server",
     "server": "cross-env NODE_ENV=development nodemon -w 'server/**/*.*' ./server/main.js",
     "start": "npm run development",

--- a/src/electron/electron.js
+++ b/src/electron/electron.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { app, BrowserWindow } = require('electron');
+const { app, BrowserWindow, globalShortcut } = require('electron');
 
 // electron-connect is used only in dev mode, node_modules are not
 // shipped in the electron package so importing electron-connect
@@ -13,9 +13,18 @@ if (process.env.NODE_ENV === 'development') {
 let win = null;
 const DEVELOPMENT = process.env.NODE_ENV === 'development';
 
-app.on('ready', function () {
+const loadUrl = () => {
+  win.loadURL(`file://${__dirname}/index.html`);
+}
+
+app.on('ready', () => {
   // Initialize the window
-  win = new BrowserWindow({ width: 1200, height: 900, autoHideMenuBar: true, frame: true });
+  win = new BrowserWindow({
+    width: 1200,
+    height: 900,
+    autoHideMenuBar: true,
+    frame: true,
+  });
 
   if (DEVELOPMENT) {
     // Specify entry point
@@ -26,13 +35,21 @@ app.on('ready', function () {
     // see /config/webpack.dev.js for further details
     client.create(win);
   } else {
-    win.loadURL(`file://${__dirname}/index.html`)
+    loadUrl();
   }
 
   // Remove window once app is closed
-  win.on('closed', function () {
+  win.on('closed', () => {
     win = null;
   });
+
+  // replace standard reload that would show a blank screen with the win.loadUrl method
+  globalShortcut.register('CommandOrControl+R', loadUrl);
+  globalShortcut.register('Shift+CommandOrControl+R', loadUrl);
+});
+
+app.on('will-quit', () => {
+  globalShortcut.unregisterAll();
 });
 
 app.on('activate', () => {
@@ -41,7 +58,7 @@ app.on('activate', () => {
   }
 });
 
-app.on('window-all-closed', function () {
+app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
     app.quit();
   }


### PR DESCRIPTION
Should fix #26 and #27 

Please let me know if it works on your side.
Another way of addressing the problem would be to create a menu item that captures the reload keyboard shortcuts like
```
const { Menu, MenuItem } = require('electron');
const template = [
  { label: app.getName(), submenu: [
    { label: 'Reload', accelerator: 'CommandOrControl+R', accelerator: 'Shift+CommandOrControl+R', click() { win.loadURL(`file://${__dirname}/index.html`) } },
    { type: 'separator' },
    { role: 'quit' }
  ] }
]
const menu = Menu.buildFromTemplate(template)

app.on('ready', function() {
  Menu.setApplicationMenu(menu);
})
```
just keeping it here for reference.