### PR TITLE
feat: added electron-builder support and separate electron documentation

### DIFF
--- a/ELECTRON.md
+++ b/ELECTRON.md
@@ -1,0 +1,60 @@
+# Running and building for Desktop with Electron
+`Electron` makes it pretty easy to run `angular2-instagram` as desktop app. To create a standalone executable we're using two packages:
+
+* `electron-builder`
+* `electron-packager`
+
+We're using both for educational purposes, a single one of those would suffice.
+
+## Configure Electron
+To configure `electron` we need to create an entry file that will be run when calling the `electron` command. You can [find it here]() on `/src/app/electron/electron.js`.
+
+## Running Electron on development and production mode
+* `npm run electron:dev` will start `webpack-dev-server` along with `electron` with hot reloading and devtools activated
+* `npm run electron:prod` will first build the app following the standard production webpack pipeline, then it will copy `/package.json` and `/src/app/electron/electron.js` to the output `/public` directory and finally run `electron`. Webpack is not running in `--watch` mode so changes won't be rebuilt
+
+## Creating the standalone executable
+This project uses both `electron-packager` and `electron-builder` to create the standalone app. Consider that you might need additional tools in order to package the app for multiple platforms using a single OS (eg. to package for Windows using Linux you will need Wine).
+
+### Building and packaging with `electron-builder`
+By running `npm run electron-builder` the app will be built in `production` mode with `webapack` and the resulting files under the `/public` folder will be packaged to create the standalone `electron` app. If no other parameter is set, the app will be packaged for the current OS and architecture (eg. macOS 64bit) and will be found under the `/dist` folder.
+If you want, for example, pack the app for Windows 32bit you could do `npm run electron-builder -- -w --ia32`. If you want to build for all 64bit platforms you should run `npm run electron-builder -- -lwm --x64`.
+
+The configuration that `electron-builder` uses to create the package is in the `build` section of `package.json`.
+Following are some useful information to keep in mind:
+* `appId` is a general name in the form of `com.electron.app-name`
+* `category` is the category in which the app can be identified, [here is a list](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/LaunchServicesKeys.html#//apple_ref/doc/uid/TP40009250-SW8) of possible categories
+* `buildResources` is the folder where backgrounds and icons are stored: a `background.png` used as macOS DMG background, app icons in the form of `icon.icns` (macOS app icon) and `icon.ico` (Windows app icon) and the same icons in `.png` format named `24x24.png`, `32x32.png`, `48x48.png`, `64x64.png`, `128x128.png`, `256x256.png` each with the corresponding dimensions
+* `files` is a list of files and folders to be packaged in the final app, defining them here also won't copy all the `node_modules` and `src` files
+* `linux` is just an example to show you can define specific target images/formats for the packaged app
+
+There is much more to it, for full documentation and examples here are some useful links:
+* [electron-builder](https://github.com/electron-userland/electron-builder)
+* [electron-builder build options](https://github.com/electron-userland/electron-builder/wiki/Options)
+* [push app updates with electron-builder](https://github.com/electron-userland/electron-builder/wiki/Auto-Update)
+
+### Building with `electron-packager`
+By running `npm run electron:packager` the following steps will happen:
+1. the app will be built in `production` mode with `webpack`
+2. the `electron.js` configuration file will be copied with its folder structure inside `/public` folder
+3. `electron-packager` will package all the contents of the `/public` folder and create an executable file under the `/dist/...` folder
+
+If no other parameter is set, the app will be packaged for the current OS and architecture (eg. macOS 64bit). To packager for multiple OS and architecture you can use the `--platform=<platform>` and `--arch=<arch>` respectively.
+
+* For a [full documentation](https://github.com/electron-userland/electron-packager) please refer to the `electron-packager` Github page.
+* For a [detailed list of all the available parameters click here](https://github.com/electron-userland/electron-packager/blob/master/usage.txt)
+
+## Publishing the executable on Github, Amazon S3...
+We are using `electron-builder` via the script `npm run electron:publish` command to create a `release` in the `angular2-instagram` repository and attach the standalone desktop app.
+This is the step by step process we follow:
+1. first [created a Github token with repo access](https://github.com/settings/tokens/new)
+2. locally set the env variable with eg. `export GH_TOKEN="<TOKEN_HERE>"`
+3. update the `version` in `package.json`, this will also be the name (prepended with a `v` eg. `0.0.2` will become `v0.0.2`) of the `release` that will be created in Github
+4. run `npm run electron:publish`
+5. go to the Github release section of the repository, edit the description and title of the release and publish it, since it was initially created by `electron-builder` as a `draft`
+
+For more info on programmatically publishing the executable on other sources you can have a look at the [official documentation on electron-builder](https://github.com/electron-userland/electron-builder/wiki/Publishing-Artifacts).
+
+----------
+
+*The packaging process has been tested for now only on Linux Mint 64bit.*

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ Once you have installed all prerequisites,
 * `npm install` to install all dependencies
 * `npm start` to run our app locally in dev mode
 
-### Running and building with Electron
-
-* `npm run electron:dev` will start `webpack-dev-server` along with `electron` with hot reloading and devtools activated
-* `npm run electron:prod` will first build the app following the standard production webpack pipeline, then it will copy `/package.json` and `/src/app/electron/electron.js` to the output `/public` directory and finally run `electron`. Webpack is not running in `--watch` mode so changes won't be rebuilt
-* `npm run electron:package` will package the `electron` app in the `/dist` folder using `electron-packager`. By default it will build the app for the current OS and architecture. For example to target OS X 64bit explicitly: `npm run package -- --platform=mas --arch=x64`. For a [detailed list of all the available parameters click here](https://github.com/electron-userland/electron-packager/blob/master/usage.txt)
+### Running, building and publishing for desktop using Electron
+[See angular2-instagram Electron specific documentation](https://github.com/JayKan/angular2-instagram/blob/master/ELECTRON.md)
+To download the standalone apps use the following links:
+* [macOS 64bit](https://github.com/JayKan/angular2-instagram/blob/master/README.md)
+* ...
 
 ## Contributors
 Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds/all-contributors#emoji-key)):

--- a/package.json
+++ b/package.json
@@ -6,7 +6,25 @@
     "name": "Jay Kan",
     "email": "leicasper@gmail.com"
   },
-  "main": "electron.js",
+  "main": "./src/electron/electron.js",
+  "build": {
+    "appId": "com.electron.angular2-instagram",
+    "mac": {
+      "category": "public.app-category.photography"
+    },
+    "directories": {
+      "buildResources": "src/electron/build",
+      "output": "dist"
+    },
+    "compression": "maximum",
+    "files": [
+      "public/**/*",
+      "src/electron/electron.js"
+    ],
+    "linux": {
+      "target": "deb"
+    }
+  },
   "scripts": {
     "add": "all-contributors add",
     "generate": "all-contributors generate",
@@ -20,8 +38,10 @@
     "development": "npm run build:dev",
     "electron:dev": "npm run build:dev -- --env.electron",
     "electron:prod": "npm run build:electron && npm run electron:copy && cross-env NODE_ENV=production electron ./public",
-    "electron:copy": "cp ./package.json ./public && cp ./src/electron/electron.js ./public",
-    "electron:package": "npm run build:electron && npm run electron:copy && electron-packager ./public --out=dist --overwrite",
+    "electron:copy": "mkdir -p ./public/src/electron && cp ./package.json ./public && cp ./src/electron/electron.js ./public/src/electron",
+    "electron:packager": "npm run build:electron && npm run electron:copy && electron-packager ./public --out=dist --overwrite",
+    "electron:builder": "npm run build:electron && build",
+    "electron:publish": "del-cli ./dist && node_modules/.bin/build -p always",
     "production": "npm run clean && npm run build && npm run server",
     "server": "cross-env NODE_ENV=development nodemon -w 'server/**/*.*' ./server/main.js",
     "start": "npm run development",
@@ -44,7 +64,6 @@
   },
   "dependencies": {
     "compression": "^1.6.2",
-    "electron": "^1.6.2",
     "express": "^4.14.0",
     "helmet": "^3.4.1",
     "serve-favicon": "^2.3.0",
@@ -52,6 +71,7 @@
     "winston": "^2.2.0"
   },
   "devDependencies": {
+    "electron": "^1.6.2",
     "@angular/common": "4.0.1",
     "@angular/compiler": "4.0.1",
     "@angular/compiler-cli": "4.0.1",
@@ -77,6 +97,7 @@
     "cross-env": "^3.1.3",
     "css-loader": "~0.26.2",
     "del-cli": "^0.2.0",
+    "electron-builder": "^16.8.2",
     "electron-connect": "^0.6.1",
     "electron-packager": "^8.6.0",
     "extract-text-webpack-plugin": "^2.0.0",

--- a/src/electron/electron.js
+++ b/src/electron/electron.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { app, BrowserWindow, globalShortcut } = require('electron');
+const fs = require('fs');
 
 // electron-connect is used only in dev mode, node_modules are not
 // shipped in the electron package so importing electron-connect
@@ -15,7 +16,11 @@ const DEVELOPMENT = process.env.NODE_ENV === 'development';
 const PRODUCTION = process.env.NODE_ENV === 'production';
 
 const loadUrl = () => {
-  win.loadURL(`file://${__dirname}/index.html`);
+  // since electron-builder and electron-packager packs the /public folder in different ways
+  // we first check if the folder exists and point to the index.html file accordingly
+  const publicFolder = fs.existsSync(`${__dirname}/../../public`) ? 'public/' : '';
+  const target = `file://${__dirname}/../../${publicFolder}index.html`;
+  win.loadURL(target);
 };
 
 app.on('ready', () => {
@@ -28,9 +33,9 @@ app.on('ready', () => {
   });
 
   if (DEVELOPMENT) {
-    // Specify entry point
+    // During development there's a webserver running (webpack-devserver)
     win.loadURL('http://localhost:3000');
-    // devtools
+    // enable devtools
     win.webContents.openDevTools();
     // in dev mode the electron window is created with electron-connect
     // see /config/webpack.dev.js for further details

--- a/src/electron/package.json
+++ b/src/electron/package.json
@@ -2,5 +2,11 @@
   "name": "angular2-instagram",
   "version": "0.0.0",
   "license": "MIT",
-  "main": "electron.js"
+  "main": "electron.js",
+  "description": "Instagram like photo filter playground built with Angular2 (Web | Desktop)",
+  "author": {
+    "name": "Jay Kan",
+    "email": "leicasper@gmail.com"
+  }
+
 }


### PR DESCRIPTION
Hi, both `electron-builder` and `electron-packager` should be working now. I managed to test them only on Linux though.

As I said [here](https://github.com/JayKan/angular2-instagram/issues/28#issuecomment-293543989) there is still something missing (icons etc..) so please let me know if you have any suggestion on how we should proceed.

Thanks